### PR TITLE
Fix page title gradient for new theme

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,8 +46,8 @@ export default {
         'gradient-brand-subtle': 'linear-gradient(135deg, #007aff20 0%, #5856d620 100%)',
         'gradient-glass': 'linear-gradient(135deg, rgba(26, 26, 26, 0.8) 0%, rgba(42, 42, 42, 0.8) 100%)',
         'gradient-overlay': 'linear-gradient(135deg, rgba(0, 0, 0, 0.4) 0%, rgba(0, 0, 0, 0.8) 100%)',
-        // Title gradient - right to left, with 15% darkness on the left
-        'gradient-title': 'linear-gradient(to left, #ffffff 0%, #ffffff 75%, #F2F2F2 90%, #D9D9D9 100%)',
+        // Title gradient - dark gradient (right to left, brightens towards right for readability)
+        'gradient-title': 'linear-gradient(to left, #ffffff 0%, #e5e5e5 70%, #b8b8b8 100%)',
       },
       placeholderColor: {
         'on-surface-dark-secondary': '#a3a3a3',


### PR DESCRIPTION
Update page title gradient to be darker and readable in the new theme.

The previous gradient was too light, causing poor legibility for page titles when displayed with the dark theme. This change introduces darker shades in the gradient while ensuring the right side remains bright for optimal contrast.

---
<a href="https://cursor.com/background-agent?bcId=bc-0527eb5f-31d5-400c-a16c-ce659eb72e9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0527eb5f-31d5-400c-a16c-ce659eb72e9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

